### PR TITLE
2 remove passenger

### DIFF
--- a/app/controllers/passengers_controller.rb
+++ b/app/controllers/passengers_controller.rb
@@ -1,0 +1,9 @@
+class PassengersController < ApplicationController
+  def destroy
+    flight = Flight.find(params[:flight_id])
+    passenger = Passenger.find(params[:passenger_id])
+    passenger_flight = FlightPassenger.find_passenger_to_delete(flight.id, passenger.id)
+    FlightPassenger.destroy(passenger_flight.id)
+    redirect_to flights_path
+  end
+end

--- a/app/models/flight_passenger.rb
+++ b/app/models/flight_passenger.rb
@@ -1,4 +1,8 @@
 class FlightPassenger < ApplicationRecord
   belongs_to :flight
   belongs_to :passenger
+
+  def self.find_passenger_to_delete(flight, passenger)
+    where("flight_id = #{flight} AND passenger_id = #{passenger}").first
+  end
 end

--- a/app/views/flights/index.html.erb
+++ b/app/views/flights/index.html.erb
@@ -4,7 +4,12 @@
       <li><h1>Flight Number: <%= flight.flight_number %> || Airline: <%= flight.airline.name %> </h1></li>
         <ul>
           <% flight.passengers.each do |passenger| %>
-            <li><%= passenger.name %></li>
+            <li><%= passenger.name %> <%= form_with url: flight_passenger_path(flight, passenger), method: :delete do |f| %>
+                                        <%= f.hidden_field :flight_id, value: flight.id %>
+                                        <%= f.hidden_field :passenger_id, value: passenger.id %>
+                                        <%= f.submit  "Remove #{passenger.name}" %>
+                                      <% end %>
+            </li>
           <% end %>
         </ul>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,11 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
-  resources :flights, only: [:index]
+  resources :flights, only: [:index] do
+  # namespace :flights, only: [:index] do
+    resources :passengers, only: [:destroy]#, controller: "flights/passengers"
+  end
+  #should be to flights/passengers
+  get "flights/:id/passengers/:id", to: "passengers#destroy"
+
 end

--- a/spec/features/flights/index_spec.rb
+++ b/spec/features/flights/index_spec.rb
@@ -47,5 +47,47 @@ RSpec.describe "flights index page", type: :feature do
         expect(page).to have_content(@passenger_5.name)
       end
     end
+
+    it "has link to remove each passenger from a given flight" do
+      within "#flight-#{@frontier_flight_1.flight_number}" do
+        expect(page).to have_content("Flight Number: #{@frontier_flight_1.flight_number} || Airline: #{@airline_1.name}")
+        expect(page).to have_content(@passenger_1.name)
+        expect(page).to have_content(@passenger_2.name)
+        expect(page).to have_button("Remove #{@passenger_1.name}")
+        expect(page).to have_button("Remove #{@passenger_2.name}")
+      end
+
+      within "#flight-#{@delta_flight_1.flight_number}" do
+        expect(page).to have_content("Flight Number: #{@delta_flight_1.flight_number} || Airline: #{@airline_2.name}")
+        expect(page).to have_content(@passenger_1.name)
+        expect(page).to have_content(@passenger_2.name)
+        expect(page).to have_content(@passenger_3.name)
+        expect(page).to have_content(@passenger_4.name)
+        expect(page).to have_content(@passenger_5.name)
+        expect(page).to have_button("Remove #{@passenger_1.name}")
+        expect(page).to have_button("Remove #{@passenger_2.name}")
+        expect(page).to have_button("Remove #{@passenger_3.name}")
+        expect(page).to have_button("Remove #{@passenger_4.name}")
+        expect(page).to have_button("Remove #{@passenger_5.name}")
+      end
+    end
+
+    it "can remove a passenger from a given flight" do
+      within "#flight-#{@frontier_flight_1.flight_number}" do
+        expect(page).to have_content("Flight Number: #{@frontier_flight_1.flight_number} || Airline: #{@airline_1.name}")
+        expect(page).to have_content(@passenger_1.name)
+        expect(page).to have_content(@passenger_2.name)
+
+        click_button("Remove #{@passenger_1.name}")
+      end
+
+      expect(current_path).to eq(flights_path)
+
+      within "#flight-#{@frontier_flight_1.flight_number}" do
+        expect(page).to have_content("Flight Number: #{@frontier_flight_1.flight_number} || Airline: #{@airline_1.name}")
+        expect(page).to_not have_content(@passenger_1.name)
+        expect(page).to have_content(@passenger_2.name)
+      end
+    end
   end
 end

--- a/spec/models/flight_passenger_spec.rb
+++ b/spec/models/flight_passenger_spec.rb
@@ -5,4 +5,36 @@ RSpec.describe FlightPassenger, type: :model do
     it { should belong_to :flight }
     it { should belong_to :passenger }
   end
+
+  describe "class methods" do
+    before(:each) do
+      @airline_1 = Airline.create!(name: "Frontier")
+      @airline_2 = Airline.create!(name: "Delta")
+
+      @frontier_flight_1 = @airline_1.flights.create!(flight_number: "1727", date: "08/03/20", departure_city: "Denver", arrival_city: "Reno")
+
+      @delta_flight_1 = @airline_2.flights.create!(flight_number: "1154", date: "08/03/20", departure_city: "Denver", arrival_city: "Tokyo")
+
+      @passenger_1 = Passenger.create!(name: "Garrett", age: 36)
+      @passenger_2 = Passenger.create!(name: "Audrey", age: 33)
+      @passenger_3 = Passenger.create!(name: "Chris", age: 48)
+      @passenger_4 = Passenger.create!(name: "Angie", age: 39)
+      @passenger_5 = Passenger.create!(name: "Luca", age: 1)
+
+      @fp_1 = FlightPassenger.create!(flight_id: @frontier_flight_1.id, passenger_id: @passenger_1.id)
+      @fp_2 = FlightPassenger.create!(flight_id: @frontier_flight_1.id, passenger_id: @passenger_2.id)
+
+      @fp_3 = FlightPassenger.create!(flight_id: @delta_flight_1.id, passenger_id: @passenger_1.id)
+      @fp_4 = FlightPassenger.create!(flight_id: @delta_flight_1.id, passenger_id: @passenger_2.id)
+      @fp_5 = FlightPassenger.create!(flight_id: @delta_flight_1.id, passenger_id: @passenger_3.id)
+      @fp_6 = FlightPassenger.create!(flight_id: @delta_flight_1.id, passenger_id: @passenger_4.id)
+      @fp_7 = FlightPassenger.create!(flight_id: @delta_flight_1.id, passenger_id: @passenger_5.id)
+    end
+
+    context "::find_passenger_to_delete" do
+      it "finds the passenger to delete" do
+        expect(FlightPassenger.find_passenger_to_delete(@frontier_flight_1.id, @passenger_1.id)).to eq(@fp_1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Functionality
all functionality from US2 complete:
```
User Story 2, Remove a Passenger from a Flight

As a visitor
When I visit the flights index page
Next to each passengers name
I see a link or button to remove that passenger from that flight
When I click on that link/button
I'm returned to the flights index page
And I no longer see that passenger listed under that flight,
And I still see the passenger listed under the other flights they were assigned to.
```

## Test Coverage @ 100% ✅ 
```zsh
garrettgregor ~/turing_work/2mod/ics/6wk-final-eval/green-violet-3969 [main] $ berf
...

Finished in 0.21439 seconds (files took 1.24 seconds to load)
3 examples, 0 failures

Coverage report generated for RSpec to /Users/garrettgregor/turing_work/2mod/ics/6wk-final-eval/green-violet-3969/coverage. 76 / 76 LOC (100.0%) covered.
garrettgregor ~/turing_work/2mod/ics/6wk-final-eval/green-violet-3969 [2-remove-passenger] $ berm
............

Finished in 0.07951 seconds (files took 1.08 seconds to load)
12 examples, 0 failures

Coverage report generated for RSpec to /Users/garrettgregor/turing_work/2mod/ics/6wk-final-eval/green-violet-3969/coverage. 103 / 103 LOC (100.0%) covered.
garrettgregor ~/turing_work/2mod/ics/6wk-final-eval/green-violet-3969 [2-remove-passenger] $ ber
...............

Finished in 0.29397 seconds (files took 1.07 seconds to load)
15 examples, 0 failures

Coverage report generated for RSpec to /Users/garrettgregor/turing_work/2mod/ics/6wk-final-eval/green-violet-3969/coverage. 120 / 120 LOC (100.0%) covered.
garrettgregor ~/turing_work/2mod/ics/6wk-final-eval/green-violet-3969 [2-remove-passenger] $ 
```